### PR TITLE
Correcao menu Dropdown Roteiro 2

### DIFF
--- a/docs/roteiros/2.Deployment.md
+++ b/docs/roteiros/2.Deployment.md
@@ -279,8 +279,7 @@ Para funcionar, o Wordpress requer um banco de dados para armazenar informaçõe
 * Instale a aplicação **charm** para utilizarmos, vamos baixar o charm do Wordpress do repositório charm-hub.
 
 ??? info "Charm"
-
-  O **charm** é como um pacote que contém instruções sobre como instalar e configurar um aplicativo, como o **Grafana**. Você simplesmente escolhe o **charm** do Grafana, define algumas configurações e o **Juju** cuida do restante, tornando o processo de implantação mais fácil e consistente em ambientes de nuvem. Entenda melhor sobre o que é o charm lendo a sua documentação [charm-hub](https://charmhub.io).
+    O **charm** é como um pacote que contém instruções sobre como instalar e configurar um aplicativo, como o **Grafana**. Você simplesmente escolhe o **charm** do Grafana, define algumas configurações e o **Juju** cuida do restante, tornando o processo de implantação mais fácil e consistente em ambientes de nuvem. Entenda melhor sobre o que é o charm lendo a sua documentação [charm-hub](https://charmhub.io).
 
 ```$ sudo snap install charm --channel=2.x/stable --classic```
 


### PR DESCRIPTION
closes #29 
Boa tarde.
Realizei a correção do menu dropdown referente à informação sobre os "charms", presente no Roteiro 2. A qual reportei no issue #29 

Inicialmente, as informações estavam aparecendo abaixo do Menu. Corrigi o markdown para a explicação sobre o "Charm" ficar dentro do menu.

Segue em anexo, uma foto da mudança aplicada em ambiente local.
![Screenshot from 2024-10-02 10-32-21](https://github.com/user-attachments/assets/a1ce305f-b442-4318-a0b8-2d43d7c493ec)
